### PR TITLE
Consistently use namespace without leading backslash, straight quotes

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,34 +1,34 @@
 <?php
-use \Punic\Calendar;
+use Punic\Calendar;
 
 include 'vendor/autoload.php';
 
 $dt = Calendar::toDateTime('2010-03-07');
 
-// This will output `AD`
+// This will output 'AD'
 echo Calendar::getEraName(1);
 
-// This will output `Mar`
+// This will output 'Mar'
 echo Calendar::getMonthName($dt, 'abbreviated');
 
-// This will output `marzo`
+// This will output 'marzo'
 echo Calendar::getMonthName($dt, 'wide', 'it');
 
-// This will output `Monday`
+// This will output 'Monday'
 echo Calendar::getWeekdayName(1);
 
-// This will output `1st quarter`
+// This will output '1st quarter'
 echo Calendar::getQuarterName(1);
 
-// This will output `7 März 2010`
+// This will output '7 März 2010'
 echo Calendar::format($dt, 'd MMMM y', 'de');
 
-// This will output `domenica 7 marzo 2010`
+// This will output 'domenica 7 marzo 2010'
 echo Calendar::formatDate($dt, 'full', 'it');
 
-// This will output `7/3/2010`
+// This will output '7/3/2010'
 echo Calendar::formatDate($dt, '~yMd', 'da');
 
-// This will output `Mar 7 – 10, 2010`
+// This will output 'Mar 7 – 10, 2010'
 $dt2 = Calendar::toDateTime('2010-03-10');
 echo Calendar::formatInterval($dt, $dt2, 'yMMMd');

--- a/currency.php
+++ b/currency.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Currency;
+use Punic\Currency;
 
 include 'vendor/autoload.php';
 

--- a/data.php
+++ b/data.php
@@ -1,13 +1,13 @@
 <?php
-use \Punic\Data,
-    \Punic\Language;
+use Punic\Data,
+    Punic\Language;
 
 include 'vendor/autoload.php';
 
-// This will print `Schweizer Hochdeutsch (Schweiz)` without specifying a second parameter for Language::getName
+// This will print 'Schweizer Hochdeutsch (Schweiz)' without specifying a second parameter for Language::getName
 Data::setDefaultLocale('de_DE');
 echo Language::getName('de_CH');
 
-// This will print `alto tedesco svizzero (Svizzera)` because the value in the second parameter of getName isn't a valid locale
+// This will print 'alto tedesco svizzero (Svizzera)' because the value in the second parameter of getName isn't a valid locale
 Data::setFallbackLocale('it_IT');
 echo Language::getName('de_CH', 'et_INVALID');

--- a/language.php
+++ b/language.php
@@ -1,10 +1,10 @@
 <?php
-use \Punic\Language;
+use Punic\Language;
 
 include 'vendor/autoload.php';
 
-// This will print `Italian (Italy)`
+// This will print 'Italian (Italy)'
 echo Language::getName('it_IT', 'en_US');
 
-// This will print `Schweizer Hochdeutsch (Schweiz)`
+// This will print 'Schweizer Hochdeutsch (Schweiz)'
 echo Language::getName('de_CH', 'de_DE');

--- a/number.php
+++ b/number.php
@@ -1,16 +1,16 @@
 <?php
-use \Punic\Number;
+use Punic\Number;
 
 include 'vendor/autoload.php';
 
-// This will print `1.234,57`
+// This will print '1.234,57'
 echo Number::format(1234.567, 2, 'it');
 
-// This will print `1,234.57`
+// This will print '1,234.57'
 echo Number::format(1234.567, 2, 'en');
 
-// This will print 1234.56
+// This will print '1234.56'
 echo Number::unformat('1.234,56', 'it');
 
-// This will print 1234.56
+// This will print '1234.56'
 echo Number::unformat('1,234.56', 'en');

--- a/phone.php
+++ b/phone.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Phone;
+use Punic\Phone;
 
 include 'vendor/autoload.php';
 

--- a/plural.php
+++ b/plural.php
@@ -1,10 +1,10 @@
 <?php
-use \Punic\Plural;
+use Punic\Plural;
 
 include 'vendor/autoload.php';
 
-// This will print `one`
+// This will print 'one'
 echo Plural::getRule(1, 'en');
 
-// This will print `other`
+// This will print 'other'
 echo Plural::getRule(2, 'en');

--- a/setup/composer.php
+++ b/setup/composer.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Unit;
+use Punic\Unit;
 
 // This will output `2 Millisekunden`
 echo Unit::format(2, 'millisecond', 'long', 'de');

--- a/setup/manual.php
+++ b/setup/manual.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Unit;
+use Punic\Unit;
 
 include 'path/to/punic.php';
 

--- a/territory.php
+++ b/territory.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Territory;
+use Punic\Territory;
 
 include 'vendor/autoload.php';
 

--- a/unit.php
+++ b/unit.php
@@ -1,5 +1,5 @@
 <?php
-use \Punic\Unit;
+use Punic\Unit;
 
 include 'vendor/autoload.php';
 


### PR DESCRIPTION
From PHP Manual:
> for namespaced names (…) the leading backslash is unnecessary and not recommended, as import names must be fully qualified